### PR TITLE
Workaround for TypeError due to protoc version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy~=1.18.5
+protobuf~=3.18.0
 scikit-learn~=0.23.2
 tensorflow~=2.3.0
 matplotlib~=3.2.2


### PR DESCRIPTION
Error described as below:
```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```